### PR TITLE
Add information for composer version 1 and PHP8

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,19 @@ Installation
 ------------
 
 Use Composer for dependency management. For instructions how to install
-Composer, see https://getcomposer.org/download/
+Composer, see https://getcomposer.org/download/.
+
+Make sure to install Composer version 1.x as Composer version 2 dropped
+PEAR support.
+
+Hint:
+```sh
+php composer-setup.php --1
+```
+
+Then clone this repository and install the dependencies. If you are developing
+horde and using PHP 8, you need to set the flag `--ignore-platform-reqs`.
+
 
 ```sh
 git clone https://github.com/horde/git-tools.git horde-git-tools


### PR DESCRIPTION
When the current version of composer (v2) is used, installing the horde dev-depencies fails with error message:
"The PEAR repository has been removed from Composer 2.x"
This commit adds information to use Composer version 1.x.

Also PHP 8 is currently not possible, as installing the dev-depencies fails with the follwoing error message for
a lot of horde dev-requirements:
"requires php <8.0.0.0 -> your PHP version (8.0.14) does not satisfy that requirement."
This commit adds the information to use the flag `--ignore-platform-reqs`.