### PR TITLE
Increase the version number for pear/pear to 1.10.10 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "pear-pear.horde.org/horde_yaml": "^2.0.6",
         "horde/components": "dev-master",
         "pear/archive_tar": "^1.4.2",
-        "pear/pear": "^1.10.0@dev"
+        "pear/pear": "^1.10.10"
     },
     "autoload": {
         "psr-4": {"Horde\\GitTools\\": "lib"}


### PR DESCRIPTION
The versions of pear/pear <1.10.10 have issues with php 8.1. After increasing the version number to 1.10.10 it was possible to build a horde system. 